### PR TITLE
should-close-projectlist-file: fix https://github.com/alibaba/git-repo-go/issues/4

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -619,6 +619,7 @@ func (v syncCommand) UpdateProjectList() error {
 				break
 			}
 		}
+ 		f.Close()
 	}
 
 	err = v.removeObsoletePaths(oldPaths, newPaths)


### PR DESCRIPTION
fix `os.Rename(projectListLockFile, projectListFile)` failure: https://github.com/alibaba/git-repo-go/issues/4

FATAL: failed to remove existing project list file 'D:\CodeBase\AOSP\.repo\project.list': remove D:\CodeBase\AOSP\.repo\project.list: The process cannot access the file because it is being used by another process.