### PR TITLE
workspace: show error if review is undefined for remote

### DIFF
--- a/project/remote.go
+++ b/project/remote.go
@@ -229,7 +229,7 @@ func (v *Project) LoadRemotes(remoteMap *RemoteMap, noCache bool) {
 
 		wg.Add(1)
 		name = strings.TrimPrefix(name, "remote.")
-		func(name string) {
+		go func(name string) {
 			defer wg.Done()
 			URL := cfg.Get("remote." + name + ".url")
 			if URL == "" {

--- a/project/remote.go
+++ b/project/remote.go
@@ -302,8 +302,7 @@ func (v *Project) AddRemote(mr *manifest.Remote, noCache bool) *Remote {
 		protoHelper helper.ProtoHelper
 	)
 
-	reviewURL := mr.Review
-	if reviewURL != "" {
+	if mr.Review != "" {
 		if mr.Type != "" {
 			sshInfo := &helper.SSHInfo{ProtoType: mr.Type}
 			protoHelper = helper.NewProtoHelper(sshInfo)

--- a/test/t0100-init.sh
+++ b/test/t0100-init.sh
@@ -54,11 +54,12 @@ test_expect_success "git config variable manifest.name = default.xml" '
 test_expect_success "two xml files checkout" '
 	(
 		cd work &&
-		# Has two xml files
+		# Has three xml files
 		ls .repo/manifests/*.xml >actual &&
 		cat >expect<<-EOF &&
 		.repo/manifests/default.xml
 		.repo/manifests/next.xml
+		.repo/manifests/remote-ro.xml
 		EOF
 		test_cmp expect actual
 	)
@@ -249,6 +250,7 @@ test_expect_success "switch branch: master, next.xml is back" '
 		cat >expect<<-EOF &&
 		.repo/manifests/default.xml
 		.repo/manifests/next.xml
+		.repo/manifests/remote-ro.xml
 		EOF
 		test_cmp expect actual
 	)

--- a/test/t0103-init-branch.sh
+++ b/test/t0103-init-branch.sh
@@ -38,7 +38,7 @@ test_expect_success "current branch = default" '
 	(
 		cd work &&
 		cat >expect <<-EOF &&
-		955eabf3fc15481b8b48a2c7d5cb8ee22440242a
+		$COMMIT_MANIFEST_0_1
 		EOF
 		cp .repo/manifests.git/HEAD actual &&
 		test_cmp expect actual

--- a/test/t0107-init-corner-cases.sh
+++ b/test/t0107-init-corner-cases.sh
@@ -36,7 +36,7 @@ test_expect_success "manifests project is detached" '
 			cat "$(git rev-parse --git-dir)/HEAD"
 		) >actual &&
 		cat >expect <<-EOF &&
-		955eabf3fc15481b8b48a2c7d5cb8ee22440242a
+		$COMMIT_MANIFEST_0_1
 		EOF
 		test_cmp expect actual
 	)
@@ -44,14 +44,12 @@ test_expect_success "manifests project is detached" '
 
 test_expect_success "new commit in manifests" '
 	(
-		cd work &&
-		(
-			cd .repo/manifests &&
-			echo hello >>README.md &&
-			git add README.md &&
-			test_tick && git commit -m test
-		)
-	)
+		cd work/.repo/manifests &&
+		echo hello >>README.md &&
+		git add README.md &&
+		test_tick && git commit -m test
+	) &&
+	COMMIT_TIP=$(git -C work/.repo/manifests rev-parse HEAD)
 '
 
 test_expect_success "git-repo sync" '
@@ -72,7 +70,7 @@ test_expect_success "manifests project is still detached after sync" '
 			cat "$(git rev-parse --git-dir)/HEAD"
 		) >actual &&
 		cat >expect <<-EOF &&
-		b2dfdb9bb35eff99a6351416abccb406b442b790
+		$COMMIT_TIP
 		EOF
 		test_cmp expect actual
 	)
@@ -101,7 +99,7 @@ test_expect_success "manifests project is detached after sync v0.2" '
 			cat "$(git rev-parse --git-dir)/HEAD"
 		) >actual &&
 		cat >expect <<-EOF &&
-		5bb6dee40bc20fcdaeeb5a2e31a900cc4c7d8727
+		$COMMIT_MANIFEST_0_2
 		EOF
 		test_cmp expect actual
 	)
@@ -373,7 +371,7 @@ test_expect_success "manifests project is detached" '
 			cat "$(git rev-parse --git-dir)/HEAD"
 		) >actual &&
 		cat >expect <<-EOF &&
-		292bf7eaf29f3948c4d11b65b25b9ef5e9c1ab4b
+		$COMMIT_MANIFEST_MASTER
 		EOF
 		test_cmp expect actual
 	)

--- a/test/t0222-sync-new-commit-in-manifests.sh
+++ b/test/t0222-sync-new-commit-in-manifests.sh
@@ -31,9 +31,10 @@ test_expect_success "create new commit in manifest default branch" '
 		echo hello >master.txt &&
 		git add master.txt &&
 		test_tick &&
-		git commit -m "manifest: update masster branch" &&
+		git commit -m "manifest: update master branch" &&
 		git push origin HEAD
-	)
+	) &&
+	COMMIT_TIP=$(git -C manifests rev-parse HEAD)
 '
 
 test_expect_success "sync again" '
@@ -51,11 +52,11 @@ test_expect_success "manifests updated successful" '
 		cd work/.repo/manifests &&
 		git config branch.default.merge &&
 		git status -s &&
-		git log -1 --oneline 
+		git log --pretty="%H %s" -1
 	) >actual &&
 	cat >expect <<-EOF &&
 	refs/heads/master
-	6d4ba54 manifest: update masster branch
+	$COMMIT_TIP manifest: update master branch
 	EOF
 	test_cmp expect actual
 '
@@ -69,10 +70,10 @@ test_expect_success "init -d and init -b Maint branch" '
 	(
 		cd work/.repo/manifests &&
 		test ! -f master.txt &&
-		git log -1 --oneline
+		git log -1 --pretty="%H %s"
 	) >actual &&
 	cat >expect <<-EOF &&
-	179106b Version 1.0
+	$COMMIT_MANIFEST_MAINT Version 1.0
 	EOF
 	test_cmp expect actual
 '
@@ -86,7 +87,8 @@ test_expect_success "create new commit in manifest Maint branch" '
 		test_tick &&
 		git commit -m "manifest: update Maint branch" &&
 		git push origin HEAD
-	)
+	) &&
+	COMMIT_TIP=$(git -C manifests rev-parse HEAD)
 '
 
 test_expect_success "sync again" '
@@ -106,11 +108,11 @@ test_expect_success "manifests (track Maint branch) updated successful" '
 		git status -s &&
 		test -f maint.txt &&
 		test ! -f master.txt &&
-		git log -1 --oneline 
+		git log -1 --pretty="%H %s"
 	) >actual &&
 	cat >expect <<-EOF &&
 	refs/heads/Maint
-	485bc52 manifest: update Maint branch
+	$COMMIT_TIP manifest: update Maint branch
 	EOF
 	test_cmp expect actual
 '

--- a/test/t0224-sync-with-ro-remote.sh
+++ b/test/t0224-sync-with-ro-remote.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+test_description="sync with read-only remote"
+
+. ./lib/sharness.sh
+
+# Create manifest repositories
+manifest_url="file://${REPO_TEST_REPOSITORIES}/hello/manifests"
+
+test_expect_success "setup" '
+	# create .repo file as a barrier, not find .repo deeper
+	touch .repo &&
+	mkdir work
+'
+
+test_expect_success "git-repo sync using remote-ro.xml" '
+	(
+		cd work &&
+		git-repo init -u $manifest_url -g all -m remote-ro.xml &&
+		git-repo sync --no-cache \
+			--mock-ssh-info-status 200 \
+			--mock-ssh-info-response \
+			"{\"host\":\"ssh.example.com\", \"port\":22, \"type\":\"agit\"}"
+	)
+'
+
+# TODO: add other test cases for remote with no review attribute.
+
+test_done

--- a/workspace/remote.go
+++ b/workspace/remote.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/alibaba/git-repo-go/helper"
@@ -29,6 +30,9 @@ func (v *RepoWorkSpace) LoadRemotes(noCache bool) error {
 
 	query = helper.NewSSHInfoQuery(v.ManifestProject.SSHInfoCacheFile())
 	for _, r := range v.Manifest.Remotes {
+		if r.Review == "" {
+			return fmt.Errorf("attribute 'review' is not defined in remote '%s'", r.Name)
+		}
 		sshInfo, err := query.GetSSHInfo(r.Review, !noCache)
 		if err != nil {
 			return err


### PR DESCRIPTION
If attribute "review" is not defined in remote element of a manifest, we
used to show error message without useful information, like:

    ERROR: bad address for review ''

Show the name of remote element if the review atrribute is empty:

    ERROR: attribute 'review' is not defined in remote '<Name>'

Signed-off-by: Jiang Xin <zhiyou.jx@alibaba-inc.com>