### PR TITLE
ssh_info api: add new field review_ref

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -72,12 +72,9 @@ const (
 	ProjectObjects   = "project-objects"
 	Projects         = "projects"
 
-	RefsChanges = "refs/changes/"
-	RefsMr      = "refs/merge-requests/"
 	RefsHeads   = "refs/heads/"
 	RefsTags    = "refs/tags/"
 	RefsPub     = "refs/published/"
-	RefsM       = "refs/remotes/m/"
 	Refs        = "refs/"
 	RefsRemotes = "refs/remotes/"
 

--- a/helper/proto-agit.go
+++ b/helper/proto-agit.go
@@ -35,7 +35,9 @@ type AGitProtoHelper struct {
 
 // NewAGitProtoHelper returns AGitProtoHelper object.
 func NewAGitProtoHelper(sshInfo *SSHInfo) *AGitProtoHelper {
-	sshInfo.User = "git"
+	if sshInfo.ReviewRefPattern == "" {
+		sshInfo.ReviewRefPattern = "refs/merge-requests/{id}/head"
+	}
 	return &AGitProtoHelper{sshInfo: sshInfo}
 }
 
@@ -200,10 +202,10 @@ func (v AGitProtoHelper) GetGitPushCommand(o *common.UploadOptions) (*GitPushCom
 }
 
 // GetDownloadRef returns reference name of the specific code review.
-func (v AGitProtoHelper) GetDownloadRef(cr, patch string) (string, error) {
-	_, err := strconv.Atoi(cr)
+func (v AGitProtoHelper) GetDownloadRef(id, patch string) (string, error) {
+	_, err := strconv.Atoi(id)
 	if err != nil {
-		return "", fmt.Errorf("bad review ID %s: %s", cr, err)
+		return "", fmt.Errorf("bad review ID %s: %s", id, err)
 	}
-	return fmt.Sprintf("refs/merge-requests/%s/head", cr), nil
+	return v.sshInfo.GetReviewRef(id, patch)
 }

--- a/helper/ssh-info_test.go
+++ b/helper/ssh-info_test.go
@@ -1,0 +1,61 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetReviewRef(t *testing.T) {
+	var (
+		ref string
+		err error
+	)
+
+	assert := assert.New(t)
+
+	sshInfo := SSHInfo{}
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.NotNil(err)
+	assert.Empty(ref)
+
+	sshInfo.ReviewRefPattern = "refs/heads/master"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs/heads/master", ref)
+
+	sshInfo.ReviewRefPattern = "refs/changes/{id:right:2}/{id}/{patch}"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs/changes/23/123/1", ref)
+
+	sshInfo.ReviewRefPattern = "refs/changes/{id:right:2}/{id}/{patch}"
+	ref, err = sshInfo.GetReviewRef("9", "1")
+	assert.Nil(err)
+	assert.Equal("refs/changes/09/9/1", ref)
+
+	sshInfo.ReviewRefPattern = "refs/changes/{id:left:2}/{id}/{patch}"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs/changes/12/123/1", ref)
+
+	sshInfo.ReviewRefPattern = "refs/changes/{id:left:2}/{id}/{patch}"
+	ref, err = sshInfo.GetReviewRef("9", "1")
+	assert.Nil(err)
+	assert.Equal("refs/changes/09/9/1", ref)
+
+	sshInfo.ReviewRefPattern = "refs/pull/{id}/head"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs/pull/123/head", ref)
+
+	sshInfo.ReviewRefPattern = "refs}/pull/{id}/head"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs}/pull/123/head", ref, "unmatched right quote")
+
+	sshInfo.ReviewRefPattern = "refs/{pull}/{id}/head"
+	ref, err = sshInfo.GetReviewRef("123", "1")
+	assert.Nil(err)
+	assert.Equal("refs/{pull}/123/head", ref, "unknown key")
+}


### PR DESCRIPTION
Add new member field review_ref in ssh_info API. When downloading a
review, return the reference name by parsing the pattern defined in
review_ref of ssh_info.

Signed-off-by: Jiang Xin <zhiyou.jx@alibaba-inc.com>