### PR TITLE
Manifest remote ssh

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -337,7 +337,7 @@ func (v *Project) gitConfigRemoteURL() string {
 	return v.GitConfigRemoteURL(remote)
 }
 
-// GetRemoteURL returns new remtoe url user provided or from manifest repo url
+// GetRemoteURL returns new remote url user provided or from manifest repo url
 func (v *Project) GetRemoteURL() (string, error) {
 	if v.Settings.ManifestURL == "" && v.IsMetaProject() {
 		v.Settings.ManifestURL = v.gitConfigRemoteURL()

--- a/project/remote.go
+++ b/project/remote.go
@@ -85,6 +85,16 @@ func (v *Project) GetRemotePushURL(remote *Remote) string {
 		log.Errorf("cannot get ssh_info for remote: %s", remote.Name)
 		return ""
 	}
+
+	if v.ManifestRemote != nil && v.ManifestRemote.PushURL != "" {
+		defaultURL = v.ManifestRemote.PushURL
+		if strings.HasSuffix(defaultURL, "/") == false {
+			defaultURL += "/"
+		}
+		defaultURL += v.Name + ".git"
+		return defaultURL
+	}
+
 	if sshInfo.Host != "" {
 		login := sshInfo.User
 		if login == "<email>" {


### PR DESCRIPTION
When using a `local_manifest/*.xml` I noticed that if I specify the `pushurl` field of a remote, it would always still use `ssh://user@host:port/repo.git`, this patch attempts to default the pushurl if it is specified in the manifest before a ssh url is generated.