### PR TITLE
Feat: Do not disable default push config(to nothing config value)

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -941,16 +941,8 @@ func (v *uploadCommand) UploadAndReport(branches []project.ReviewableBranch) err
 			branch.Uploaded = false
 			branch.Error = err
 			haveErrors = true
-		} else {
-			branch.Uploaded = true
-			// Disable default push for single repo workspace,
-			// because for multple repository, push.default has
-			// already been disabled in `git repo sync` process.
-			if v.ws.IsSingle() && theProject != nil {
-				// push command must have specific refspec
-				theProject.DisableDefaultPush()
-			}
 		}
+		branch.Uploaded = true
 	}
 
 	fmt.Fprintln(os.Stderr, "")

--- a/test/t0500-review.sh
+++ b/test/t0500-review.sh
@@ -241,16 +241,16 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 	)
 '
 
-test_expect_success "push.default has been set to nothing" '
-	(
-		cd work/main &&
-		git config push.default
-	) >actual &&
-	cat >expect<<-EOF &&
-	nothing
-	EOF
-	test_cmp expect actual
-'
+#test_expect_success "push.default has been set to nothing" '
+#	(
+#		cd work/main &&
+#		git config push.default
+#	) >actual &&
+#	cat >expect<<-EOF &&
+#	nothing
+#	EOF
+#	test_cmp expect actual
+#'
 
 test_expect_success "will upload one commit for review (http/dryrun/draft/with edit options)" '
 	(

--- a/test/t0503-review-Maint.sh
+++ b/test/t0503-review-Maint.sh
@@ -126,16 +126,16 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 	)
 '
 
-test_expect_success "push.default has been set to nothing" '
-	(
-		cd work/main &&
-		git config push.default
-	) >actual &&
-	cat >expect<<-EOF &&
-	nothing
-	EOF
-	test_cmp expect actual
-'
+#test_expect_success "push.default has been set to nothing" '
+#	(
+#		cd work/main &&
+#		git config push.default
+#	) >actual &&
+#	cat >expect<<-EOF &&
+#	nothing
+#	EOF
+#	test_cmp expect actual
+#'
 
 test_expect_success "will upload one commit for review (http/dryrun/draft/with edit options)" '
 	(

--- a/test/t0508-review-git-worktree.sh
+++ b/test/t0508-review-git-worktree.sh
@@ -239,16 +239,16 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 	)
 '
 
-test_expect_success "push.default has been set to nothing" '
-	(
-		cd work/Maint &&
-		git config push.default
-	) >actual &&
-	cat >expect<<-EOF &&
-	nothing
-	EOF
-	test_cmp expect actual
-'
+#test_expect_success "push.default has been set to nothing" '
+#	(
+#		cd work/Maint &&
+#		git config push.default
+#	) >actual &&
+#	cat >expect<<-EOF &&
+#	nothing
+#	EOF
+#	test_cmp expect actual
+#'
 
 test_expect_success "will upload one commit for review (http/dryrun/draft/with edit options)" '
 	(


### PR DESCRIPTION
The config 'push.default=nothing' should not be rewritten, this may
cause confusion for users.

Signed-off-by: Dyrone Teng <tenglong.tl@alibaba-inc.com>