### PR TITLE
sync: check published ref if has --check-published option

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -47,6 +47,7 @@ type syncCommand struct {
 		NetworkOnly            bool
 		DetachHead             bool
 		CurrentBranchOnly      bool
+		CheckPublished         bool
 		Jobs                   int
 		ManifestName           string
 		NoCache                bool
@@ -105,6 +106,10 @@ func (v *syncCommand) Command() *cobra.Command {
 		"c",
 		false,
 		"fetch only current branch from server")
+	v.cmd.Flags().BoolVar(&v.O.CheckPublished,
+		"check-published",
+		false,
+		"do not sync project which is published but not merged")
 	v.cmd.Flags().IntVarP(&v.O.Jobs,
 		"jobs",
 		"j",

--- a/project/local-half.go
+++ b/project/local-half.go
@@ -23,9 +23,10 @@ import (
 type CheckoutOptions struct {
 	RepoSettings
 
-	Quiet      bool
-	DetachHead bool
-	IsManifest bool
+	Quiet          bool
+	DetachHead     bool
+	IsManifest     bool
+	CheckPublished bool
 }
 
 // IsClean indicates git worktree is clean.
@@ -300,7 +301,7 @@ func (v Project) SyncLocalHalf(o *CheckoutOptions) error {
 	}
 
 	// Manifest project do not need to check publish ref.
-	if !o.IsManifest {
+	if !o.IsManifest && o.CheckPublished {
 		pubid := v.PublishedRevision(branch)
 		// Local branched is published.
 		if pubid != "" {


### PR DESCRIPTION
Add new option `--check-published` for `git-repo sync`.  By default, sync project without checking published reference.

