### PR TITLE
arm64: native Apple Silicon (M1) support to Mac builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GOBUILD_WINDOWS_64 := env GOOS=windows GOARCH=amd64 $(GOBUILD)
 GOBUILD_WINDOWS_32 := env GOOS=windows GOARCH=386 $(GOBUILD)
 GOBUILD_MAC_64 := env GOOS=darwin GOARCH=amd64 $(GOBUILD)
 GOBUILD_MAC_32 := env GOOS=darwin GOARCH=386 $(GOBUILD)
+GOBUILD_MAC_ARM64 := env GOOS=darwin GOARCH=arm64 $(GOBUILD)
 
 BUILD_RELEASE_FLAG=-ldflags "-s -w"
 
@@ -147,6 +148,17 @@ _build/$(REPO_VERSION)/macOS-32/git-repo: FORCE
 		$(SHA256SUM) $(shell basename $@) >$(shell basename $@).sha256 && \
 		$(GPGSIGN) -o $(shell basename $@).sha256.gpg $(shell basename $@).sha256 && \
 		$(TAR) -zcvf ../git-repo-$(REPO_VERSION)-macOS-32.tar.gz --transform "s/^\./git-repo-$(REPO_VERSION)-macOS-32/" .)
+
+macOS-arm64: _build/$(REPO_VERSION)/macOS-arm64/git-repo
+_build/$(REPO_VERSION)/macOS-arm64/git-repo: FORCE
+	$(call message,Building $@)
+	@mkdir -p $(shell dirname $@)
+	$(GOBUILD_MAC_ARM64) $(RELEASE_LDFLAGS) -o $@
+	$(UPX) $@
+	(cd $(shell dirname $@) && \
+		$(SHA256SUM) $(shell basename $@) >$(shell basename $@).sha256 && \
+		$(GPGSIGN) -o $(shell basename $@).sha256.gpg $(shell basename $@).sha256 && \
+		$(TAR) -zcvf ../git-repo-$(REPO_VERSION)-macOS-arm64.tar.gz --transform "s/^\./git-repo-$(REPO_VERSION)-macOS-arm64/" .)
 
 index:
 	$(call message,Building $@)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -107,6 +107,8 @@ func (v *upgradeInfo) URLs(isProduction bool) []string {
 		arch = "32"
 	case "amd64":
 		arch = "64"
+	case "arm64":
+		arch = "arm64"
 	}
 
 	url = strings.ReplaceAll(url, "<version>", v.Version(isProduction))

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -37,6 +37,8 @@ func TestUpgradeInfoURLs(t *testing.T) {
 		archType = "32"
 	case "amd64":
 		archType = "64"
+	case "arm64":
+		archType = "arm64"
 	}
 
 	uinfo = upgradeInfo{


### PR DESCRIPTION
Add the option to build arm64 in Makefile.
Support the option of arm64 arch in the program self-upgrade.

Signed-off-by: bojun.cbj <bojun.cbj@alibaba-inc.com>