### PR TITLE
Zpf/tracking multiple branch

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -882,7 +882,7 @@ func (v *uploadCommand) UploadAndReport(branches []project.ReviewableBranch) err
 		}
 
 		if v.O.CodeReview.Empty() {
-			oldOid = theProject.PublishedRevision(branch.Branch.Name)
+			oldOid = theProject.PublishedRevision(branch)
 
 			destBranch, err = v.getDestBranch(branch)
 			if err != nil {

--- a/project/local-half.go
+++ b/project/local-half.go
@@ -302,7 +302,9 @@ func (v Project) SyncLocalHalf(o *CheckoutOptions) error {
 
 	// Manifest project do not need to check publish ref.
 	if !o.IsManifest && o.CheckPublished {
-		pubid := v.PublishedRevision(branch)
+		remote := v.GetBranchRemote(branch, false)
+		rb := v.GetUploadableBranch(branch, remote, "")
+		pubid := v.PublishedRevision(rb)
 		// Local branched is published.
 		if pubid != "" {
 			notMerged, err := v.Revlist(pubid, "--not", revid)

--- a/project/upload.go
+++ b/project/upload.go
@@ -86,7 +86,7 @@ func (v ReviewableBranch) AppendReviewers(people [][]string) {
 func (v *ReviewableBranch) Published() *Reference {
 	pub := Reference{}
 	if v.CodeReview.Empty() {
-		pub.Name = config.RefsPub + v.Branch.ShortName()
+		pub.Name = config.RefsPub + v.Branch.ShortName() + "/" + strings.TrimLeft(v.RemoteTrack.Branch, config.RefsHeads)
 	} else {
 		pub.Name = v.CodeReview.Ref
 	}
@@ -214,7 +214,7 @@ func (v ReviewableBranch) UploadForReview(o *config.UploadOptions) error {
 		msg          string
 	)
 	if v.CodeReview.Empty() {
-		publishedRef = config.RefsPub + branchName
+		publishedRef = config.RefsPub + branchName + "/" + strings.TrimPrefix(v.RemoteTrack.Branch, config.RefsHeads)
 		msg = fmt.Sprintf("review from %s to %s on %s",
 			branchName,
 			o.DestBranch,
@@ -229,6 +229,12 @@ func (v ReviewableBranch) UploadForReview(o *config.UploadOptions) error {
 		v.Project.Prompt(),
 		publishedRef,
 		msg)
+	/*
+		clean old-styled published refs (refs/published/<source branch>) first, so that new-styled
+		published refs (refs/published/<source branch>/<target branch>) could be created.
+	*/
+	p.CleanPublishedCache()
+
 	err = p.UpdateRef(publishedRef,
 		config.RefsHeads+branchName,
 		msg)

--- a/test/t0400-upload-basic.sh
+++ b/test/t0400-upload-basic.sh
@@ -139,7 +139,7 @@ test_expect_success "with new commit, ready for upload (edit push options)" '
 		#         <hash>
 		
 		NOTE: main> will execute command: git push --receive-pack=agit-receive-pack ssh://git@ssh.example.com/main.git refs/heads/my/topic1:refs/for/Maint/my/topic1
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -166,7 +166,7 @@ test_expect_success "agit-flow proto v2: no agit-receive-pack, and push with env
 		NOTE: main> will execute command: git push ssh://git@ssh.example.com/main.git refs/heads/my/topic1:refs/for/Maint/my/topic1
 		NOTE: main> with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: main> with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -239,7 +239,7 @@ test_expect_success "upload --dryrun --drafts" '
 		NOTE: main> will execute command: git push ssh://git@ssh.example.com/main.git refs/heads/my/topic1:refs/drafts/Maint/my/topic1
 		NOTE: main> with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: main> with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -280,7 +280,7 @@ test_expect_success "upload --dryrun" '
 		cat >>expect<<-EOF &&
 		NOTE: main> with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: main> with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -339,7 +339,7 @@ test_expect_success "check update-ref" '
 	(
 		cd work &&
 		( cd main && git rev-parse refs/heads/my/topic1 ) >expect &&
-		( cd main && git rev-parse refs/published/my/topic1 ) >actual &&
+		( cd main && git rev-parse refs/published/my/topic1/Maint ) >actual &&
 		test_cmp expect actual
 	)
 '

--- a/test/t0401-upload-gerrit.sh
+++ b/test/t0401-upload-gerrit.sh
@@ -91,7 +91,7 @@ test_expect_success "upload --dryrun --drafts (with cache)" '
 		         <hash>
 		to https://example.com (y/N)? Yes
 		NOTE: main> will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com/main.git refs/heads/my/topic1:refs/drafts/Maint
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -117,7 +117,7 @@ test_expect_success "upload --dryrun --drafts (no cache)" '
 		         <hash>
 		to https://example.com (y/N)? Yes
 		NOTE: main> will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/main.git refs/heads/my/topic1:refs/drafts/Maint
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -146,7 +146,7 @@ test_expect_success "upload --dryrun with reviewers" '
 		         <hash>
 		to https://example.com (y/N)? Yes
 		NOTE: main> will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/main.git refs/heads/my/topic1:refs/for/Maint/my/topic1%r=user1,r=user2,r=user3,r=user4,cc=user5,cc=user6,cc=user7,private,wip
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0406-upload-with-different-pushurl.sh
+++ b/test/t0406-upload-with-different-pushurl.sh
@@ -105,7 +105,7 @@ test_expect_success "pushurl in manifest override ssh-info response" '
 		NOTE: main> will execute command: git push -o oldoid=<hash> ssh://committer@aone.example.com/agit/main.git refs/heads/my/topic1:refs/for/Maint/my/topic1
 		NOTE: main> with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: main> with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -141,7 +141,7 @@ test_expect_success "use pushurl in ssh-info response" '
 		         <hash>
 		to https://example.com (y/N)? Yes
 		NOTE: main> will execute command: git -c http.extraHeader=AGIT-FLOW: git-repo/n.n.n.n push -o oldoid=<hash> https://committer@git.example.com/agit/main.git refs/heads/my/topic1:refs/for/Maint/my/topic1
-		NOTE: main> will update-ref refs/published/my/topic1 on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
+		NOTE: main> will update-ref refs/published/my/topic1/Maint on refs/heads/my/topic1, reason: review from my/topic1 to Maint on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0500-review.sh
+++ b/test/t0500-review.sh
@@ -220,7 +220,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/master/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -283,7 +283,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/with e
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/master/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -324,7 +324,7 @@ test_expect_success "will upload one commit for review (http/dryrun)" '
 		cat >>expect<<-EOF &&
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -387,7 +387,7 @@ test_expect_success "published ref will be created" '
 	(
 		cd work &&
 		( cd main && git rev-parse refs/heads/my/topic-test ) >expect &&
-		( cd main && git rev-parse refs/published/my/topic-test ) >actual &&
+		( cd main && git rev-parse refs/published/my/topic-test/master ) >actual &&
 		test_cmp expect actual
 	)
 '
@@ -468,7 +468,7 @@ test_expect_success "upload to a ssh review url (no ssh_info cache)" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/master/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:10022
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:10022
 
 		----------------------------------------------------------------------
 		EOF
@@ -510,7 +510,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, use ssh
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/for/master/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -543,7 +543,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, no-cach
 		         <hash>
 		to ssh://git@example.com:29418 (y/N)? Yes
 		NOTE: will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/jiangxin/main.git refs/heads/my/topic-test:refs/for/master
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -576,7 +576,7 @@ test_expect_success "upload to gerrit ssh review url (use ssh_info cache)" '
 		         <hash>
 		to ssh://git@example.com:29418 (y/N)? Yes
 		NOTE: will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/jiangxin/main.git refs/heads/my/topic-test:refs/for/master
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -611,7 +611,7 @@ test_expect_success "upload to a ssh review using rcp style URL" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/for/master/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com
+		NOTE: will update-ref refs/published/my/topic-test/master on refs/heads/my/topic-test, reason: review from my/topic-test to master on ssh://git@example.com
 
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0502-review-different-branch.sh
+++ b/test/t0502-review-different-branch.sh
@@ -88,7 +88,7 @@ test_expect_success "upload: pr --br <branch> to upload specific branch" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/drafts/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0503-review-Maint.sh
+++ b/test/t0503-review-Maint.sh
@@ -105,7 +105,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic:refs/drafts/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -168,7 +168,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/with e
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic:refs/drafts/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -209,7 +209,7 @@ test_expect_success "will upload one commit for review (http/dryrun)" '
 		cat >>expect<<-EOF &&
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -272,7 +272,7 @@ test_expect_success "published ref will be created" '
 	(
 		cd work &&
 		( cd main && git rev-parse refs/heads/jx/topic ) >expect &&
-		( cd main && git rev-parse refs/published/jx/topic ) >actual &&
+		( cd main && git rev-parse refs/published/jx/topic/Maint ) >actual &&
 		test_cmp expect actual
 	)
 '
@@ -325,7 +325,7 @@ test_expect_success "upload to a ssh review url" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com:10022/jiangxin/main.git refs/heads/jx/topic:refs/for/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:10022
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:10022
 
 		----------------------------------------------------------------------
 		EOF
@@ -368,7 +368,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, use ssh
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com:10022/jiangxin/main.git refs/heads/jx/topic:refs/for/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -402,7 +402,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, no-cach
 		         <hash>
 		to ssh://git@example.com:29418 (y/N)? Yes
 		NOTE: will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@example.com:29418/jiangxin/main.git refs/heads/jx/topic:refs/for/Maint
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -437,7 +437,7 @@ test_expect_success "upload to gerrit ssh review url" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com:10022/jiangxin/main.git refs/heads/jx/topic:refs/for/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -476,7 +476,7 @@ test_expect_success "upload to a ssh review using rcp style URL" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic:refs/for/Maint/jx/topic
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com
+		NOTE: will update-ref refs/published/jx/topic/Maint on refs/heads/jx/topic, reason: review from jx/topic to Maint on ssh://git@example.com
 
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0505-review-one-remote-no-tracking.sh
+++ b/test/t0505-review-one-remote-no-tracking.sh
@@ -86,7 +86,7 @@ test_expect_success "upload --dest <branch>" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -124,7 +124,7 @@ test_expect_success "upload --br <branch> --dest <branch>" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0506-review-two-remotes-default-origin.sh
+++ b/test/t0506-review-two-remotes-default-origin.sh
@@ -91,7 +91,7 @@ test_expect_success "upload --dest <branch>, with warning" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -128,7 +128,7 @@ test_expect_success "upload with specific remote, no warning" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0507-review-two-remotes-select-remote.sh
+++ b/test/t0507-review-two-remotes-select-remote.sh
@@ -81,7 +81,7 @@ test_expect_success "upload --remote 1st --dest <branch>" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF
@@ -119,7 +119,7 @@ test_expect_success "upload --remote 1st --br <branch> --dest <branch>" '
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/jx/topic1:refs/for/master/jx/topic1
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/jx/topic1 on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
+		NOTE: will update-ref refs/published/jx/topic1/master on refs/heads/jx/topic1, reason: review from jx/topic1 to master on https://example.com
 		
 		----------------------------------------------------------------------
 		EOF

--- a/test/t0508-review-git-worktree.sh
+++ b/test/t0508-review-git-worktree.sh
@@ -218,7 +218,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/no-edi
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/Maint/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -281,7 +281,7 @@ test_expect_success "will upload one commit for review (http/dryrun/draft/with e
 		NOTE: will execute command: git push ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/Maint/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -322,7 +322,7 @@ test_expect_success "will upload one commit for review (http/dryrun)" '
 		cat >>expect<<-EOF &&
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on https://example.com
 
 		----------------------------------------------------------------------
 		EOF
@@ -385,7 +385,7 @@ test_expect_success "published ref will be created" '
 	(
 		cd work &&
 		( cd Maint && git rev-parse refs/heads/my/topic-test ) >expect &&
-		( cd Maint && git rev-parse refs/published/my/topic-test ) >actual &&
+		( cd Maint && git rev-parse refs/published/my/topic-test/Maint ) >actual &&
 		test_cmp expect actual
 	)
 '
@@ -466,7 +466,7 @@ test_expect_success "upload to a ssh review url (no ssh_info cache)" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/drafts/Maint/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:10022
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:10022
 
 		----------------------------------------------------------------------
 		EOF
@@ -508,7 +508,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, use ssh
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/for/Maint/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -541,7 +541,7 @@ test_expect_success "upload to gerrit ssh review url (assume-no, dryrun, no-cach
 		         <hash>
 		to ssh://git@example.com:29418 (y/N)? Yes
 		NOTE: will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/jiangxin/main.git refs/heads/my/topic-test:refs/for/Maint
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -574,7 +574,7 @@ test_expect_success "upload to gerrit ssh review url (use ssh_info cache)" '
 		         <hash>
 		to ssh://git@example.com:29418 (y/N)? Yes
 		NOTE: will execute command: git push --receive-pack=gerrit receive-pack ssh://committer@ssh.example.com:29418/jiangxin/main.git refs/heads/my/topic-test:refs/for/Maint
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com:29418
 
 		----------------------------------------------------------------------
 		EOF
@@ -609,7 +609,7 @@ test_expect_success "upload to a ssh review using rcp style URL" '
 		NOTE: will execute command: git push -o oldoid=<hash> ssh://git@ssh.example.com/jiangxin/main.git refs/heads/my/topic-test:refs/for/Maint/my/topic-test
 		NOTE: with extra environment: AGIT_FLOW=git-repo/n.n.n.n
 		NOTE: with extra environment: GIT_SSH_COMMAND=ssh -o SendEnv=AGIT_FLOW
-		NOTE: will update-ref refs/published/my/topic-test on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com
+		NOTE: will update-ref refs/published/my/topic-test/Maint on refs/heads/my/topic-test, reason: review from my/topic-test to Maint on ssh://git@example.com
 
 		----------------------------------------------------------------------
 		EOF


### PR DESCRIPTION
Currently git-repo doesn't support creating merge-requests from a same branch to multiple remote branch with the same change. For example, first create a merge-request from local branch topic to remote branch master, and switch topic's remote tracking branch to remote branch main, then execute pr and you got remind "no change in project . (branch master) since last upload":
```
IT-C02YW0UGLVDL:sky zhaopengfei$ git pr
对象计数中: 3, 完成.
Delta compression using up to 8 threads.
压缩对象中: 100% (2/2), 完成.
写入对象中: 100% (3/3), 289 bytes | 289.00 KiB/s, 完成.
Total 3 (delta 0), reused 0 (delta 0)
remote: 2021/12/06 19:56:43 debug logging disabled
remote: +-------------------------------------------------------------------------------------+
remote: | Merge Request #23168 was created or updated.                                        |
remote: | View merge request at URL:                                                          |
remote: | https://codeup.aliyun.com/6183ea91e84c82e792916acc/sky/merge_request/23168 |
remote: +-------------------------------------------------------------------------------------+
remote: 2021/12/06 19:56:45 debug logging disabled
To https://codeup.aliyun.com/6183ea91e84c82e792916acc/sky.git
 * [new branch]      master -> refs/for/master/master

----------------------------------------------------------------------
IT-C02YW0UGLVDL:sky zhaopengfei$ 
IT-C02YW0UGLVDL:sky zhaopengfei$ 
IT-C02YW0UGLVDL:sky zhaopengfei$ git branch -u origin/main
分支 master 设置为跟踪来自 origin 的远程分支 main。
IT-C02YW0UGLVDL:sky zhaopengfei$ 
IT-C02YW0UGLVDL:sky zhaopengfei$ git pr
NOTE: no change in project . (branch master) since last upload
NOTE: no branches ready for upload
```

The reason behind is that git-repo has a local cache to avoid creating seem merge-request repeatedly. Specifically, 
git-repo keeps published status (tip commit id) of each local branch in a special ref "**refs/published/\<branch\>**", each
time we create a merge-request from a local branch "topic", git-repo first check if "topic's" tip commit is equal to the
commit kept in ref "refs/published/topic", if they are equal, git-repo will reject the creating mr request and remind us 
"no change in project . (branch ***) since last upload", otherwise, git-repo will create a mr and keeps/updates "topic's"
tip commit id in ref "refs/published/topic". Above cache mechanism means you cannot create mr from a specific local 
branch to multiple remote branch with the same change.

To remove above limitation, this pr changes above cache mechanism, it keeps published status of merge-requests instead 
of local branches. Specifically, when you create a mr from a local branch to a remote branch, it keeps local branch's tip
commit id in a special ref "**refs/published/\<local branch\>/\<remote branch\>**". 